### PR TITLE
make CivilTime constexpr aware. (I strongly favor the name CalendarTime btw)

### DIFF
--- a/src/stx/CivilTime.cc
+++ b/src/stx/CivilTime.cc
@@ -13,19 +13,6 @@
 
 namespace stx {
 
-CivilTime::CivilTime() :
-    year_(0),
-    month_(0),
-    day_(0),
-    hour_(0),
-    minute_(0),
-    second_(0),
-    millisecond_(0),
-    offset_(0) {}
-
-
-CivilTime::CivilTime(std::nullptr_t) : CivilTime() {}
-
 Option<CivilTime> CivilTime::parseString(
     const String& str,
     const char* fmt /* = "%Y-%m-%d %H:%M:%S" */) {
@@ -51,38 +38,6 @@ Option<CivilTime> CivilTime::parseString(
     ct.setYear(t.tm_year + 1900);
     return Some(ct);
   }
-}
-
-uint16_t CivilTime::year() const {
-  return year_;
-}
-
-uint8_t CivilTime::month() const {
-  return month_;
-}
-
-uint8_t CivilTime::day() const {
-  return day_;
-}
-
-uint8_t CivilTime::hour() const {
-  return hour_;
-}
-
-uint8_t CivilTime::minute() const {
-  return minute_;
-}
-
-uint8_t CivilTime::second() const {
-  return second_;
-}
-
-uint16_t CivilTime::millisecond() const {
-  return millisecond_;
-}
-
-int32_t CivilTime::offset() const {
-  return offset_;
 }
 
 void CivilTime::setYear(uint16_t value) {

--- a/src/stx/CivilTime.h
+++ b/src/stx/CivilTime.h
@@ -22,12 +22,12 @@ public:
   /**
    * Create a new CivilTime instance with all fields set to zero
    */
-  CivilTime();
+  constexpr CivilTime();
 
   /**
    * Create a new CivilTime instance with all fields set to zero
    */
-  CivilTime(std::nullptr_t);
+  constexpr CivilTime(std::nullptr_t);
 
   /**
    * Parse time from the provided string
@@ -54,42 +54,42 @@ public:
   /**
    * Year including century / A.D. (eg. 1999)
    */
-  uint16_t year() const;
+  constexpr uint16_t year() const;
 
   /**
    * Month [1-12]
    */
-  uint8_t month() const;
+  constexpr uint8_t month() const;
 
   /**
    * Day of the month [1-31]
    */
-  uint8_t day() const;
+  constexpr uint8_t day() const;
 
   /**
    * Hour [0-23]
    */
-  uint8_t hour() const;
+  constexpr uint8_t hour() const;
 
   /**
    * Hour [0-59]
    */
-  uint8_t minute() const;
+  constexpr uint8_t minute() const;
 
   /**
    * Second [0-60]
    */
-  uint8_t second() const;
+  constexpr uint8_t second() const;
 
   /**
    * Millisecond [0-999]
    */
-  uint16_t millisecond() const;
+  constexpr uint16_t millisecond() const;
 
   /**
    * Timezone offset to UTC in seconds
    */
-  int32_t offset() const;
+  constexpr int32_t offset() const;
 
   void setYear(uint16_t value);
   void setMonth(uint8_t value);
@@ -112,3 +112,5 @@ protected:
 };
 
 }
+
+#include <stx/CivilTime_impl.h>

--- a/src/stx/CivilTime_impl.h
+++ b/src/stx/CivilTime_impl.h
@@ -1,0 +1,49 @@
+namespace stx {
+
+inline constexpr CivilTime::CivilTime() :
+    year_(0),
+    month_(0),
+    day_(0),
+    hour_(0),
+    minute_(0),
+    second_(0),
+    millisecond_(0),
+    offset_(0) {}
+
+inline constexpr CivilTime::CivilTime(std::nullptr_t) :
+    CivilTime() {
+}
+
+inline constexpr uint16_t CivilTime::year() const {
+  return year_;
+}
+
+inline constexpr uint8_t CivilTime::month() const {
+  return month_;
+}
+
+inline constexpr uint8_t CivilTime::day() const {
+  return day_;
+}
+
+inline constexpr uint8_t CivilTime::hour() const {
+  return hour_;
+}
+
+inline constexpr uint8_t CivilTime::minute() const {
+  return minute_;
+}
+
+inline constexpr uint8_t CivilTime::second() const {
+  return second_;
+}
+
+inline constexpr uint16_t CivilTime::millisecond() const {
+  return millisecond_;
+}
+
+inline constexpr int32_t CivilTime::offset() const {
+  return offset_;
+}
+
+} // namespace stx


### PR DESCRIPTION
make CivilTime constexpr aware. (I strongly favor the name CalendarTime btw)

  ... as CalendarTime makes much more sense to me, though.
