### PR TITLE
make UnixTime constexpr-aware.

### DIFF
--- a/src/stx/UnixTime.cc
+++ b/src/stx/UnixTime.cc
@@ -17,9 +17,9 @@
 
 namespace stx {
 
-UnixTime::UnixTime() : utc_micros_(WallClock::unixMicros()) {}
-
-UnixTime::UnixTime(uint64_t utc_time) : utc_micros_(utc_time) {}
+UnixTime::UnixTime() :
+    utc_micros_(WallClock::unixMicros()) {
+}
 
 UnixTime::UnixTime(const CivilTime& civil) {
   uint64_t days = civil.day() - 1;
@@ -43,44 +43,7 @@ UnixTime::UnixTime(const CivilTime& civil) {
 
 UnixTime& UnixTime::operator=(const UnixTime& other) {
   utc_micros_ = other.utc_micros_;
-  tz_offset_ = other.tz_offset_;
   return *this;
-}
-
-bool UnixTime::operator==(const UnixTime& other) const {
-  return utc_micros_ < other.utc_micros_;
-}
-
-bool UnixTime::operator<(const UnixTime& other) const {
-  return utc_micros_ < other.utc_micros_;
-}
-
-bool UnixTime::operator>(const UnixTime& other) const {
-  return utc_micros_ > other.utc_micros_;
-}
-
-bool UnixTime::operator<=(const UnixTime& other) const {
-  return utc_micros_ <= other.utc_micros_;
-}
-
-bool UnixTime::operator>=(const UnixTime& other) const {
-  return utc_micros_ >= other.utc_micros_;
-}
-
-UnixTime::operator uint64_t() const {
-  return utc_micros_;
-}
-
-UnixTime::operator double() const {
-  return utc_micros_;
-}
-
-uint64_t UnixTime::unixMicros() const {
-  return utc_micros_;
-}
-
-UnixTime UnixTime::epoch() {
-  return UnixTime(0);
 }
 
 UnixTime UnixTime::now() {

--- a/src/stx/UnixTime.h
+++ b/src/stx/UnixTime.h
@@ -32,7 +32,7 @@ public:
    *
    * @param timestamp the UTC microsecond timestamp
    */
-  UnixTime(uint64_t utc_time);
+  constexpr UnixTime(uint64_t utc_time);
 
   /**
    * Create a new UTC UnixTime instance from a civil time reference
@@ -72,33 +72,33 @@ public:
 
   UnixTime& operator=(const UnixTime& other);
 
-  bool operator==(const UnixTime& other) const;
-  bool operator<(const UnixTime& other) const;
-  bool operator>(const UnixTime& other) const;
-  bool operator<=(const UnixTime& other) const;
-  bool operator>=(const UnixTime& other) const;
+  constexpr bool operator==(const UnixTime& other) const;
+  constexpr bool operator<(const UnixTime& other) const;
+  constexpr bool operator>(const UnixTime& other) const;
+  constexpr bool operator<=(const UnixTime& other) const;
+  constexpr bool operator>=(const UnixTime& other) const;
 
   /**
    * Cast the UnixTime object to a UTC unix microsecond timestamp represented as
    * an uint64_t
    */
-  explicit operator uint64_t() const;
+  constexpr explicit operator uint64_t() const;
 
   /**
    * Cast the UnixTime object to a UTC unix microsecond timestamp represented as
    * a double
    */
-  explicit operator double() const;
+  constexpr explicit operator double() const;
 
   /**
    * Return the represented date/time as a UTC unix microsecond timestamp
    */
-  uint64_t unixMicros() const;
+  constexpr uint64_t unixMicros() const;
 
   /**
    * Return a new UnixTime instance with time 00:00:00 UTC, 1 Jan. 1970
    */
-  static UnixTime epoch();
+  static constexpr UnixTime epoch();
 
   /**
    * Return a new UnixTime instance with time = now
@@ -116,12 +116,6 @@ protected:
    * The utc microsecond timestamp of the represented moment in time
    */
   uint64_t utc_micros_;
-
-  /**
-   * The time zone offset to UTC in seconds
-   */
-  uint32_t tz_offset_;
-
 };
 
 }
@@ -134,4 +128,5 @@ public:
 };
 }
 
+#include <stx/UnixTime_impl.h>
 #endif

--- a/src/stx/UnixTime_impl.h
+++ b/src/stx/UnixTime_impl.h
@@ -1,0 +1,43 @@
+namespace stx {
+
+inline constexpr UnixTime::UnixTime(uint64_t utc_time) :
+    utc_micros_(utc_time) {
+}
+
+inline constexpr bool UnixTime::operator==(const UnixTime& other) const {
+  return utc_micros_ < other.utc_micros_;
+}
+
+inline constexpr bool UnixTime::operator<(const UnixTime& other) const {
+  return utc_micros_ < other.utc_micros_;
+}
+
+inline constexpr bool UnixTime::operator>(const UnixTime& other) const {
+  return utc_micros_ > other.utc_micros_;
+}
+
+inline constexpr bool UnixTime::operator<=(const UnixTime& other) const {
+  return utc_micros_ <= other.utc_micros_;
+}
+
+inline constexpr bool UnixTime::operator>=(const UnixTime& other) const {
+  return utc_micros_ >= other.utc_micros_;
+}
+
+inline constexpr UnixTime::operator uint64_t() const {
+  return utc_micros_;
+}
+
+inline constexpr UnixTime::operator double() const {
+  return utc_micros_;
+}
+
+inline constexpr uint64_t UnixTime::unixMicros() const {
+  return utc_micros_;
+}
+
+inline constexpr UnixTime UnixTime::epoch() {
+  return UnixTime(0);
+}
+
+} // namespace stx


### PR DESCRIPTION
also remove `tz_offset_` as it was dead code only anyways.
(add it back _only_ when you really need it)

NOTE: this branch should be pulled _after_ the CivilTime pull request.
