### PR TITLE
MonotonicClock API

### DIFF
--- a/src/stx/CMakeLists.txt
+++ b/src/stx/CMakeLists.txt
@@ -170,6 +170,7 @@ add_library(stx-base STATIC
     Language.cc
     logging.cc
     logging/logoutputstream.cc
+    MonotonicClock.cc
     net/dnscache.cc
     net/tcpserver.cc
     net/udpserver.cc

--- a/src/stx/MonotonicClock.cc
+++ b/src/stx/MonotonicClock.cc
@@ -1,0 +1,46 @@
+#include <stx/MonotonicClock.h>
+#include <stx/Duration.h>
+#include <stx/exception.h>
+#include <stx/defines.h>
+#include <stx/sysconfig.h>
+
+#if defined(STX_OS_DARWIN)
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
+
+namespace stx {
+
+#if defined(STX_OS_DARWIN)
+mach_timebase_info_data_t timebaseInfo;
+
+STX_INIT static void tbi_initialize() {
+  mach_timebase_info(&timebaseInfo);
+}
+#endif
+
+MonotonicTime MonotonicClock::now() {
+#if defined(HAVE_CLOCK_GETTIME) // POSIX realtime API
+  timespec ts;
+  int rv = clock_gettime(CLOCK_MONOTONIC, &ts);
+
+  if (rv < 0)
+    RAISE_ERRNO(kRuntimeError, "Could not retrieve clock.");
+
+  uint64_t nanos =
+      Duration::fromSeconds(ts.tv_sec).microseconds() * 1000 +
+      ts.tv_nsec;
+
+  return MonotonicTime(nanos);
+#elif defined(STX_OS_DARWIN)
+  uint64_t machTimeUnits = mach_absolute_time();
+  uint64_t nanos = machTimeUnits * timebaseInfo.numer / timebaseInfo.denom;
+
+  return MonotonicTime(nanos);
+#else
+  // TODO
+  #error "MonotonicClock: Your platform is not implemented."
+#endif
+}
+
+} // namespace stx

--- a/src/stx/MonotonicClock.h
+++ b/src/stx/MonotonicClock.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stx/MonotonicTime.h>
+
+namespace stx {
+
+/**
+ * Monotonic Clock Provider API.
+ *
+ * This API is mainly usable in Scheduler implementations to
+ * effectively implement timers and timeouts.
+ */
+class MonotonicClock {
+public:
+  /**
+   * Retrieves the current monotonic time.
+   */
+  static MonotonicTime now();
+};
+
+} // namespace stx


### PR DESCRIPTION
schau mal bitte.

im prinzip straight forward.

@paulasmuth  ich will das als extra klasse haben damit die spaeter _verschiedenen_ Scheduler implementationen (select, epoll, kqueue, ...) kein code duplizieren.
