### PR TITLE
Duration casts

### DIFF
--- a/src/stx/Duration.h
+++ b/src/stx/Duration.h
@@ -16,6 +16,7 @@
 #include <inttypes.h>
 #include <limits>
 #include <string>
+#include <time.h>                   // struct timeval; struct timespec;
 #include <stx/time_constants.h>
 
 namespace stx {
@@ -39,6 +40,20 @@ public:
    */
   constexpr Duration(uint64_t microseconds);
 
+  /**
+   * Creates a new Duration out of a @c timeval struct.
+   *
+   * @param value duration as @c timeval.
+   */
+  constexpr Duration(const struct timeval& value);
+
+  /**
+   * Creates a new Duration out of a @c timespec struct.
+   *
+   * @param value duration as @c timespec.
+   */
+  constexpr Duration(const struct timespec& value);
+
   constexpr bool operator==(const Duration& other) const;
   constexpr bool operator!=(const Duration& other) const;
   constexpr bool operator<(const Duration& other) const;
@@ -48,6 +63,9 @@ public:
   constexpr bool operator!() const;
 
   constexpr Duration operator+(const Duration& other) const;
+
+  constexpr operator struct timeval() const;
+  constexpr operator struct timespec() const;
 
   /**
    * Return the represented duration in microseconds

--- a/src/stx/Duration.h
+++ b/src/stx/Duration.h
@@ -45,14 +45,14 @@ public:
    *
    * @param value duration as @c timeval.
    */
-  constexpr Duration(const struct timeval& value);
+  Duration(const struct timeval& value);
 
   /**
    * Creates a new Duration out of a @c timespec struct.
    *
    * @param value duration as @c timespec.
    */
-  constexpr Duration(const struct timespec& value);
+  Duration(const struct timespec& value);
 
   constexpr bool operator==(const Duration& other) const;
   constexpr bool operator!=(const Duration& other) const;

--- a/src/stx/Duration_impl.h
+++ b/src/stx/Duration_impl.h
@@ -9,6 +9,8 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#include <stx/defines.h>
+
 namespace stx {
 
 inline constexpr Duration::Duration(ZeroType)
@@ -17,10 +19,10 @@ inline constexpr Duration::Duration(ZeroType)
 inline constexpr Duration::Duration(uint64_t microseconds)
     : micros_(microseconds) {}
 
-inline constexpr Duration::Duration(const timeval& value)
+inline Duration::Duration(const timeval& value)
     : micros_(value.tv_sec + value.tv_usec * kMicrosPerSecond) {}
 
-inline constexpr Duration::Duration(const timespec& value)
+inline Duration::Duration(const timespec& value)
     : micros_(value.tv_sec + value.tv_nsec * kMicrosPerSecond / 1000) {}
 
 constexpr bool Duration::operator==(const Duration& other) const {

--- a/src/stx/Duration_impl.h
+++ b/src/stx/Duration_impl.h
@@ -17,6 +17,12 @@ inline constexpr Duration::Duration(ZeroType)
 inline constexpr Duration::Duration(uint64_t microseconds)
     : micros_(microseconds) {}
 
+inline constexpr Duration::Duration(const timeval& value)
+    : micros_(value.tv_sec + value.tv_usec * kMicrosPerSecond) {}
+
+inline constexpr Duration::Duration(const timespec& value)
+    : micros_(value.tv_sec + value.tv_nsec * kMicrosPerSecond / 1000) {}
+
 constexpr bool Duration::operator==(const Duration& other) const {
   return micros_ == other.micros_;
 }
@@ -43,6 +49,28 @@ constexpr bool Duration::operator>=(const Duration& other) const {
 
 constexpr bool Duration::operator!() const {
   return micros_ == 0;
+}
+
+inline constexpr Duration::operator struct timeval() const {
+#if defined(STX_OS_DARWIN)
+  // OS/X plays in it's own universe. ;(
+  return { static_cast<time_t>(micros_ / kMicrosPerSecond),
+           static_cast<__darwin_suseconds_t>(micros_ % kMicrosPerSecond) };
+#else
+  return { static_cast<time_t>(micros_ / kMicrosPerSecond),
+           static_cast<long>(micros_ % kMicrosPerSecond) };
+#endif
+}
+
+inline constexpr Duration::operator struct timespec() const {
+#if defined(STX_OS_DARWIN)
+  // OS/X plays in it's own universe. ;(
+  return { static_cast<time_t>(micros_ / kMicrosPerSecond),
+           (static_cast<__darwin_suseconds_t>(micros_ % kMicrosPerSecond) * 1000) };
+#else
+  return { static_cast<time_t>(micros_ / kMicrosPerSecond),
+           (static_cast<long>(micros_ % kMicrosPerSecond) * 1000) };
+#endif
 }
 
 inline constexpr uint64_t Duration::microseconds() const noexcept {


### PR DESCRIPTION
@paulasmuth  hey Paul, das sind die type casts vonden ich gesprochen hatte.

fuer `timeval` und `timespec`;

eigentlich sehr sehr nice, ABER es compiled iwie nicht unter osx, weil o.g. types nur forward declared wurden (angeblich), unter linux compiled es aber. magst du mal schauen? vielleicht faellt dir ja ein warum. :)

Cheers.
